### PR TITLE
Ignore text between triple-backticks (``` code ```)

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -1061,7 +1061,7 @@ function toggle(tab, toggleLang) {
   chrome.tabs.sendMessage(tab.id, {enabled: (currentBadge === BADGE.ON), lang: currentPageSetting.lang}, function (res) {
     if (!res) {
       // When the extension had just been installed and the page has not yet been refreshed,
-      // the content script will not yet have loaded and the page would therefor need a refresh.
+      // the content script will not yet have loaded and the page would therefore need a refresh.
       return;
     }
 

--- a/js/bookmarklet.js
+++ b/js/bookmarklet.js
@@ -1,11 +1,12 @@
 /*
- * Instant Smart Quotes by Florian Zemke, Regex by Muthu Kannan
+ * Instant Smart Quotes by Florian Zemke, Regex by Muthu Kannan and Geoffrey Booth
  * https://github.com/Zemke/instant-smart-quotes
  *
  * Replace typewriter quotes, apostrophes, ellipses and dashes
  * with their typographically correct counterparts as you type.
  *
  * Wrap in backticks `"Thou shalt not use dumb quotes."` to ignore.
+ * Also ignores triple-backtick ``` "code blocks" ```.
  */
 
 var enabled;
@@ -38,7 +39,7 @@ document.addEventListener('input', function () {
   };
 
   var replaceTypewriterPunctuation = function (g) {
-    var splitterRegex = /`[\S\s]*?`/g;
+    var splitterRegex = /(?:```[\S\s]*?(?:```|$))|(?:`[\S\s]*?(?:`|$))/g;
     var f = false,
       d = "",
       h = g.split(splitterRegex);

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Instant Smart Quotes",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Replace typewriter quotes, apostrophes, ellipses and dashes with their typographically correct counterparts as you type.",
   "author": "Florian Zemke",
   "homepage_url": "https://github.com/Zemke/instant-smart-quotes",


### PR DESCRIPTION
Fixes #4. Now when you type a code block containing quotes, e.g.:

```js
JSON.parse({ "key": "val" });
```

The quotes inside the code block (between the triple backticks) are left alone.

Code between single backticks is also still ignored, and code outside of backticks should still get their replacements.